### PR TITLE
Remove unused variable and BYTES_MAX

### DIFF
--- a/bytes.c
+++ b/bytes.c
@@ -22,7 +22,6 @@
 
 long long
 string_to_bytes(const char *str) {
-  size_t len = strlen(str);
   long long val = strtoll(str, NULL, 10);
   if (!val) return -1;
   if (strstr(str, "kb")) return val * KB;

--- a/bytes.c
+++ b/bytes.c
@@ -37,17 +37,13 @@ string_to_bytes(const char *str) {
 
 char *
 bytes_to_string(long long bytes) {
-  char *str = malloc(BYTES_MAX);
-  if (!str) return NULL;
   long div = 1;
-  char *fmt;
-
-  if (bytes < KB) fmt = "%lldb";
+  char *str, *fmt;
+  if (bytes < KB) { fmt = "%lldb"; }
   else if (bytes < MB) { fmt = "%lldkb"; div = KB; }
   else if (bytes < GB) { fmt = "%lldmb"; div = MB; }
   else { fmt = "%lldgb"; div = GB; }
-  snprintf(str, BYTES_MAX, fmt, bytes / div);
-
+  asprintf(&str, fmt, bytes / div);
   return str;
 }
 

--- a/bytes.h
+++ b/bytes.h
@@ -8,12 +8,6 @@
 #ifndef BYTES
 #define BYTES
 
-// max buffer length
-
-#ifndef BYTES_MAX
-#define BYTES_MAX 256
-#endif
-
 // prototypes
 
 long long


### PR DESCRIPTION
- Variable is never used in function string_to_bytes()
- Use asprintf instead of snprintf in bytes_to_string() and get rid of BYTES_MAX
